### PR TITLE
Modify LR button to pre-populate email

### DIFF
--- a/templates/client_form.php
+++ b/templates/client_form.php
@@ -25,10 +25,11 @@ function dele()
 			</div>
 			<br><br>
 			<div class="navitem">
-				<h5><a id="contacts_button" href="mailto:masmallclaims@gmail.com">Legal Research <i class="glyphicon glyphicon-new-window"></i></a></h5>
+				<h5><a id="lr_button" href="mailto:masmallclaims@gmail.com">Legal Research <i class="glyphicon glyphicon-new-window"></i></a></h5>
 			</div>
 			<div class="navitem">
-				<h5><a id="contacts_button" href="mailto:regina_fairfax@college.harvard.edu,poconnor@college.harvard.edu">Office <i class="glyphicon glyphicon-new-window"></i></a></h5>
+				<!-- todo: change this to be a constant and update with new office director -->
+				<h5><a id="office_button" href="mailto:regina_fairfax@college.harvard.edu,poconnor@college.harvard.edu">Office <i class="glyphicon glyphicon-new-window"></i></a></h5>
 			</div>
 			<?php
 				if (isset($client["Email"]) && $client["Email"] != "")
@@ -170,7 +171,9 @@ function dele()
 	
 	constants.addConstants({
 		clientId : <?php echo $client["ClientID"] ?>, 
-	}); 	
+	});
+
+	let clientEmail = "<?php echo $client["Email"] ?>";
 	var updatedClient = 0;
 	var updatingPriority = false; 
 	function updateClient() {
@@ -224,7 +227,8 @@ function dele()
 						//"' class='alert'>Client successfully updated at " + toSqlDate(myDate()) +"!</div>");
 						//var x = updatedClient; 
 						//setTimeout(function(){$("#updated" + x).remove()}, 5000); 
-
+						clientEmail = data.Email;
+						updateLRButton(clientEmail, contacts); // contacts array is defined in contact_form.php
 						if (!updatingPriority) {
 							// indicate completion
 							$("#progress").width("100%");

--- a/templates/contact_form.php
+++ b/templates/contact_form.php
@@ -261,6 +261,39 @@
 		}
 	}
 
+
+	/**
+	 * Generate the subject and body for a referral email to LR.
+	 * Updates the mailto address with a string that sets subject
+	 * to contain the client ID and body to contain the client email
+	 * and text of last contact.
+	 *
+	 * @param {string} clientEmail - email of client, can be undefined or empty
+	 * @param {string[]} contacts - sorted array of contacts
+	 */
+
+	function updateLRButton(clientEmail, contacts) {
+		const subject = `LR Referral for Client ID ${constants.clientId}`;
+		let body = "";
+		const newline = "%0D%0A";
+
+		if (!clientEmail || clientEmail === "") { // email is undefined or empty
+			body += `No email for client.${newline.repeat(2)}`;
+		} else {
+			body += `Client email: ${clientEmail} ${newline.repeat(2)}`;
+		}
+
+		if (contacts.length > 0) {
+			const lastContact = contacts[0];
+			// pretty string with html tags removed
+			const summary = lastContact.ContactSummary.replace(/(<([^>]+)>)/gi, "");
+			body += `Summary of last contact, added by ${lastContact.UserName.Added}:
+					${newline}${summary}`;
+		}
+
+		$("#lr_button").attr("href", `mailto:masmallclaims@gmail.com?Subject=${subject}&Body=${body}`);
+	}
+
 	function updateContact(id) {
 		if(checkDateInput(id)) {
 			// disable save button
@@ -335,8 +368,9 @@
 						} else {
 							contacts[index] = newContact; 
 						}
-						
-						display();	
+
+						display();
+
 						updatePriority();
 						hideEdit();
 
@@ -532,8 +566,9 @@
 		}
 
 		htmlOutput += "</tbody></table>";
-	
 		$("#PutContactsHere").append(htmlOutput);
+
+		updateLRButton(clientEmail, contacts);
 	}
 		
 	$(document).ready(function() {


### PR DESCRIPTION
This PR defines a new function so that when the "Legal Research" button is clicked, an email like below will launch from the user's email client. The email contains the client ID, email (if set), and the summary of the last contact.
![image](https://user-images.githubusercontent.com/43190126/100530123-a7429e00-31b3-11eb-8aa2-a4a350e37bbe.png)
